### PR TITLE
Added pull up resistor to z endstop in printer.cfg

### DIFF
--- a/firmware/Klipper/printer.cfg
+++ b/firmware/Klipper/printer.cfg
@@ -135,7 +135,7 @@ rotation_distance: 40
 gear_ratio: 80:16
 microsteps: 16
 ##  In Z- Position
-endstop_pin: PA0
+endstop_pin: ^PA0
 ##  Z-position of nozzle (in mm) to z-endstop trigger point relative to print surface (Z0)
 ##  (+) value = endstop above Z0, (-) value = endstop below
 ##	Increasing position_endstop brings nozzle closer to the bed


### PR DESCRIPTION
In my testing, not having the pull up resistor enabled for the z endstop causes delays in homing which will crash your gantry into the nozzle probe. Adding the pull up resistor like the other endstops have fixes this.